### PR TITLE
make settings app distinguishable from official "microG settings"

### DIFF
--- a/play-services-core/src/main/res/values-v26/ic_app_background.xml
+++ b/play-services-core/src/main/res/values-v26/ic_app_background.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_app_background">#00897B</color>
+    <color name="ic_app_background">#1B1B1B</color>
 </resources>


### PR DESCRIPTION
This PR changes the app icon background color to the one from the ReVanced logo to make the settings app distinguishable from the official one.
As you can see, this PR is minimal-invasive (as you can see, one line in one xml file is changed) and requires less maintenance than for example the change of the `basePackageName`
Please merge this PR, I think it is in your (and the microG-team's) best interest to improve distinguishability of the two forks (and therefore adds to the goal of being able to run those in parallel). Thanks!