### PR TITLE
  Fix Missing DynamiteApplicationContext after GmsCore package rename

### DIFF
--- a/play-services-auth-api-phone/core/src/main/kotlin/org/microg/gms/auth/phone/SmsRetrieverCore.kt
+++ b/play-services-auth-api-phone/core/src/main/kotlin/org/microg/gms/auth/phone/SmsRetrieverCore.kt
@@ -41,7 +41,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.microg.gms.auth.phone.SmsRetrieverRequestType.RETRIEVER
 import org.microg.gms.auth.phone.SmsRetrieverRequestType.USER_CONSENT
-import org.microg.gms.common.Constants
 import org.microg.gms.utils.getSignatures
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
@@ -140,7 +139,7 @@ class SmsRetrieverCore(private val context: Context, override val lifecycle: Lif
 
     private fun sendUserConsentBroadcast(request: SmsRetrieverRequest, messageBody: String) {
         val userConsentIntent = Intent(context, UserConsentPromptActivity::class.java)
-        userConsentIntent.setPackage(Constants.GMS_PACKAGE_NAME)
+        userConsentIntent.setPackage(context.packageName)
         userConsentIntent.putExtra(EXTRA_MESSENGER, Messenger(object : Handler(Looper.getMainLooper()) {
             override fun handleMessage(msg: Message) {
                 if (Binder.getCallingUid() == Process.myUid()) {

--- a/play-services-base/core/src/main/java/org/microg/gms/common/PackageUtils.java
+++ b/play-services-base/core/src/main/java/org/microg/gms/common/PackageUtils.java
@@ -342,6 +342,12 @@ public class PackageUtils {
         return processName.equals(context.getPackageName());
     }
 
+    @NonNull
+    public static String getSelfPackageName(@NonNull Context context) {
+        Context appContext = context.getApplicationContext();
+        return appContext != null ? appContext.getPackageName() : context.getPackageName();
+    }
+
     public static void warnIfNotPersistentProcess(Class<?> clazz) {
         if (!isPersistentProcess()) {
             Log.w("GmsPackageUtils", clazz.getSimpleName() + " initialized outside persistent process", new RuntimeException());

--- a/play-services-core/src/main/java/com/google/android/gms/chimera/DynamiteContextFactory.java
+++ b/play-services-core/src/main/java/com/google/android/gms/chimera/DynamiteContextFactory.java
@@ -20,8 +20,6 @@ import com.google.android.gms.chimera.container.DynamiteContext;
 import com.google.android.gms.chimera.container.DynamiteModuleInfo;
 import com.google.android.gms.chimera.container.FilteredClassLoader;
 
-import org.microg.gms.common.Constants;
-
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,21 +34,7 @@ public class DynamiteContextFactory {
     private static final Map<String, ClassLoader> sClassLoaderCache = new HashMap<>();
 
     private static Context createGmsPackageContext(Context context) throws PackageManager.NameNotFoundException {
-        String[] candidates = new String[] {
-                BuildConfig.APPLICATION_ID,
-                Constants.USER_MICROG_PACKAGE_NAME,
-                Constants.GMS_PACKAGE_NAME
-        };
-
-        for (String packageName : candidates) {
-            try {
-                return context.createPackageContext(packageName, 0);
-            } catch (PackageManager.NameNotFoundException e) {
-                Log.d(TAG, "Unable to create package context for " + packageName);
-            }
-        }
-
-        throw new PackageManager.NameNotFoundException("No supported GMS package context found");
+        return context.createPackageContext(BuildConfig.APPLICATION_ID, 0);
     }
 
     public static DynamiteContext createDynamiteContext(String moduleId, Context originalContext) {

--- a/play-services-core/src/main/java/org/microg/gms/auth/login/LoginActivity.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/login/LoginActivity.java
@@ -137,7 +137,7 @@ public class LoginActivity extends AssistantActivity {
                 if (uriPath != null && uriPath.contains("/signup")) {
                     String biz = uri.getQueryParameter("biz");
                     Intent intent = new Intent(LoginActivity.this, MainActivity.class);
-                    intent.setPackage(GMS_PACKAGE_NAME);
+                    intent.setPackage(getPackageName());
                     intent.putExtra(EXTRA_URL, biz != null ? GOOGLE_SIGNUP_URL + "?biz=" + biz : GOOGLE_SIGNUP_URL);
                     startActivityForResult(intent, REQUEST_CODE_SIGNUP);
                     return true;
@@ -461,7 +461,7 @@ public class LoginActivity extends AssistantActivity {
 
     private void notifyGcmGroupUpdate(String accountName) {
         Intent intent = new Intent(ACTION_GCM_REGISTER_ACCOUNT);
-        intent.setPackage(Constants.GMS_PACKAGE_NAME);
+        intent.setPackage(getPackageName());
         intent.putExtra(KEY_GCM_REGISTER_ACCOUNT_NAME, accountName);
         sendBroadcast(intent);
     }

--- a/play-services-core/src/main/java/org/microg/gms/games/GamesStubService.java
+++ b/play-services-core/src/main/java/org/microg/gms/games/GamesStubService.java
@@ -50,7 +50,7 @@ public class GamesStubService extends BaseService {
         }
         if (packageName == null) packageName = GMS_PACKAGE_NAME;
         Intent intent = new Intent(ACTION_PLAY_GAMES_UPGRADE);
-        intent.setPackage(GMS_PACKAGE_NAME);
+        intent.setPackage(getPackageName());
         intent.putExtra(EXTRA_GAME_PACACKE_NAME, packageName);
         Bundle bundle = new Bundle();
         bundle.putParcelable("pendingIntent", PendingIntentCompat.getActivity(this, packageName.hashCode(), intent, FLAG_UPDATE_CURRENT, false));

--- a/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
@@ -506,7 +506,7 @@ public class McsService extends Service implements Handler.Callback {
 
     private void notifyGcmConnected() {
         Intent intent = new Intent(ACTION_GCM_CONNECTED);
-        intent.setPackage(Constants.GMS_PACKAGE_NAME);
+        intent.setPackage(getPackageName());
         sendBroadcast(intent);
     }
 

--- a/play-services-core/src/main/kotlin/org/microg/gms/accountsettings/ui/MainActivity.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/accountsettings/ui/MainActivity.kt
@@ -332,7 +332,7 @@ class MainActivity : AppCompatActivity() {
         Log.d(TAG, "updateVerifyNotification: notificationId: $notificationId")
         if (notificationId == -1) return
         Intent(ACTION_GCM_NOTIFY_COMPLETE).apply {
-            setPackage(GMS_PACKAGE_NAME)
+            setPackage(packageName)
             putExtra(EXTRA_NOTIFICATION_ACCOUNT, accountName)
         }.let { sendBroadcast(it) }
     }

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/identity/AuthorizationService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/identity/AuthorizationService.kt
@@ -45,7 +45,6 @@ import org.microg.gms.auth.signin.getServerAuthTokenManager
 import org.microg.gms.auth.signin.performSignIn
 import org.microg.gms.auth.signin.scopeUris
 import org.microg.gms.common.AccountUtils
-import org.microg.gms.common.Constants
 import org.microg.gms.common.GmsService
 import org.microg.gms.common.PackageUtils
 import java.util.concurrent.atomic.AtomicInteger
@@ -107,7 +106,7 @@ class AuthorizationServiceImpl(val context: Context, val packageName: String, ov
                     defaultAccount?.name?.let { setAccountName(it) }
                 }.build()
                 val intent = Intent(context, AuthSignInActivity::class.java).apply {
-                    `package` = Constants.GMS_PACKAGE_NAME
+                    `package` = PackageUtils.getSelfPackageName(context)
                     putExtra("config", SignInConfiguration(packageName, options))
                 }
                 AuthorizationResult(

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/folsom/KeyRetrievalService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/folsom/KeyRetrievalService.kt
@@ -35,8 +35,8 @@ import com.google.android.gms.common.internal.GetServiceRequest
 import com.google.android.gms.common.internal.IGmsCallbacks
 import org.microg.gms.BaseService
 import org.microg.gms.auth.folsom.ui.GenericActivity
-import org.microg.gms.common.Constants.GMS_PACKAGE_NAME
 import org.microg.gms.common.GmsService
+import org.microg.gms.common.PackageUtils
 import org.microg.gms.utils.warnOnTransactionIssues
 
 private const val TAG = "KeyRetrievalService"
@@ -149,7 +149,7 @@ class KeyRetrievalServiceImpl(val context: Context) : IKeyRetrievalService.Stub(
         callback: IKeyRetrievalCallback?, accountName: String?, type: Int, metadata: ApiMetadata?
     ) {
         Log.d(TAG, "Not implemented startUxFlow accountName:$accountName type:$type metadata:$metadata")
-        val intent = Intent().apply { setClassName(GMS_PACKAGE_NAME, GenericActivity::class.java.name) }
+        val intent = Intent().apply { setClassName(PackageUtils.getSelfPackageName(context), GenericActivity::class.java.name) }
         val pendingIntent = PendingIntentCompat.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT, false)
         val states = Status(CommonStatusCodes.SUCCESS, "UX flow PendingIntent retrieved.", pendingIntent)
         callback?.onResult(states)

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/AssistedSignInActivity.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/AssistedSignInActivity.kt
@@ -20,7 +20,6 @@ import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.common.api.Status
 import com.google.android.gms.common.internal.safeparcel.SafeParcelableSerializer
 import org.microg.gms.auth.AuthConstants
-import org.microg.gms.common.Constants
 
 const val ACTION_ASSISTED_SIGN_IN = "com.google.android.gms.auth.api.credentials.ASSISTED_SIGNIN"
 const val GET_SIGN_IN_INTENT_REQUEST = "get_sign_in_intent_request"
@@ -98,7 +97,7 @@ class AssistedSignInActivity : AppCompatActivity() {
         Log.d(TAG, "prepareSignIn options:$googleSignInOptions")
         val signInConfiguration = SignInConfiguration(clientPackageName!!, googleSignInOptions!!)
         val intent = Intent(this, AuthSignInActivity::class.java).apply {
-            `package` = Constants.GMS_PACKAGE_NAME
+            `package` = this@AssistedSignInActivity.packageName
             putExtra("config", signInConfiguration)
             putExtra("nonce", signInIntentRequest?.nonce)
         }

--- a/play-services-core/src/main/kotlin/org/microg/gms/credential/CredentialManagerService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/credential/CredentialManagerService.kt
@@ -29,7 +29,6 @@ import com.google.android.gms.credential.manager.common.ISettingsCallback
 import com.google.android.gms.credential.manager.firstparty.internal.ICredentialManagerService
 import com.google.android.gms.credential.manager.invocationparams.CredentialManagerInvocationParams
 import org.microg.gms.BaseService
-import org.microg.gms.common.Constants
 import org.microg.gms.common.GmsService
 import org.microg.gms.common.GooglePackagePermission
 import org.microg.gms.common.PackageUtils
@@ -63,7 +62,7 @@ private class CredentialManagerServiceImpl(private val context: Context, overrid
         lifecycleScope.launchWhenStarted {
             runCatching {
                 val intent = Intent().apply {
-                    setClassName(Constants.GMS_PACKAGE_NAME, PASSWORD_MANAGER_CLASS_NAME)
+                    setClassName(PackageUtils.getSelfPackageName(context), PASSWORD_MANAGER_CLASS_NAME)
                     putExtra(EXTRA_KEY_ACCOUNT_NAME, params.account.name)
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 }

--- a/play-services-core/src/main/kotlin/org/microg/gms/games/GamesService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/games/GamesService.kt
@@ -51,7 +51,6 @@ import org.microg.gms.auth.AuthConstants
 import org.microg.gms.auth.AuthManager
 import org.microg.gms.auth.AuthPrefs
 import org.microg.gms.auth.signin.checkAccountAuthStatus
-import org.microg.gms.common.Constants
 import org.microg.gms.common.GmsService
 import org.microg.gms.common.PackageUtils
 import org.microg.gms.games.achievements.AchievementsApiClient
@@ -580,7 +579,7 @@ class GamesServiceImpl(val context: Context, override val lifecycle: Lifecycle, 
 
     private fun getGamesIntent(action: String, block: Intent.() -> Unit = {}) = Intent(action).apply {
         // Jump to internal page implementation
-        setPackage(Constants.GMS_PACKAGE_NAME)
+        setPackage(PackageUtils.getSelfPackageName(context))
         putExtra(EXTRA_ACCOUNT_KEY, Integer.toHexString(account.name.hashCode()))
         putExtra(EXTRA_GAME_PACKAGE_NAME, packageName)
         addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)

--- a/play-services-core/src/main/kotlin/org/microg/gms/games/ui/GamesUiFragment.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/games/ui/GamesUiFragment.kt
@@ -41,7 +41,6 @@ import kotlinx.coroutines.withContext
 import org.microg.gms.auth.AuthConstants
 import org.microg.gms.auth.AuthManager
 import org.microg.gms.auth.signin.SignInConfigurationService
-import org.microg.gms.common.Constants
 import org.microg.gms.games.ACTION_VIEW_ACHIEVEMENTS
 import org.microg.gms.games.ACTION_VIEW_LEADERBOARDS
 import org.microg.gms.games.ACTION_VIEW_LEADERBOARDS_SCORES
@@ -348,7 +347,7 @@ class GamesUiFragment : BottomSheetDialogFragment() {
             }
         }?.adapter = LeaderboardsAdapter(context, loadLeaderboards) { leaderboard ->
             val intent = Intent(ACTION_VIEW_LEADERBOARDS_SCORES)
-            intent.setPackage(Constants.GMS_PACKAGE_NAME)
+            intent.setPackage(context.packageName)
             intent.putExtra(EXTRA_GAME_PACKAGE_NAME, clientPackageName)
             intent.putExtra(EXTRA_ACCOUNT_KEY, Integer.toHexString(currentAccount?.name.hashCode()))
             intent.putExtra(EXTRA_LEADERBOARD_ID, leaderboard.id)

--- a/play-services-core/src/main/kotlin/org/microg/gms/gcm/GcmInGmsService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/gcm/GcmInGmsService.kt
@@ -122,7 +122,7 @@ class GcmInGmsService : LifecycleService() {
                     handleIntent(intent)
                 } else {
                     val intent = Intent(ACTION_GCM_RECONNECT).apply {
-                        setPackage(Constants.GMS_PACKAGE_NAME)
+                        setPackage(this@GcmInGmsService.packageName)
                     }
                     sendBroadcast(intent)
                 }
@@ -270,7 +270,7 @@ class GcmInGmsService : LifecycleService() {
         val content = notificationData.content ?: return
         val intentExtras = notificationData.intentActions?.primaryPayload?.extras ?: return
         val intent = Intent(this, MainActivity::class.java).apply {
-            `package` = Constants.GMS_PACKAGE_NAME
+            `package` = this@GcmInGmsService.packageName
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK
             intentExtras.forEach { putExtra(it.key, it.value_) }
             putExtra(KEY_NOTIFICATION_ID, notificationId)
@@ -309,9 +309,9 @@ class GcmInGmsService : LifecycleService() {
         }
         Log.d(TAG, "updateGroupsWithAccount extras: $extras")
         val intent = Intent(GcmConstants.ACTION_GCM_SEND).apply {
-            setPackage(Constants.GMS_PACKAGE_NAME)
+            setPackage(this@GcmInGmsService.packageName)
             putExtras(extras)
-            putExtra(GcmConstants.EXTRA_APP, Intent().apply { setPackage(Constants.GMS_PACKAGE_NAME) }.let { PendingIntentCompat.getBroadcast(this@GcmInGmsService, 0, it, 0, false) })
+            putExtra(GcmConstants.EXTRA_APP, Intent().apply { setPackage(this@GcmInGmsService.packageName) }.let { PendingIntentCompat.getBroadcast(this@GcmInGmsService, 0, it, 0, false) })
         }.also {
             it.putExtra(GcmConstants.EXTRA_MESSENGER, Messenger(object : Handler(Looper.getMainLooper()) {
                 override fun handleMessage(msg: Message) {
@@ -387,7 +387,7 @@ class GcmInGmsService : LifecycleService() {
         } else {
             Log.d(TAG, "registerGcmInGms: sendBroadcast: ${intent.action}")
             Intent(intent.action).apply {
-                setPackage(Constants.GMS_PACKAGE_NAME)
+                setPackage(this@GcmInGmsService.packageName)
                 putExtras(intent)
             }.let { sendBroadcast(it) }
         }

--- a/play-services-core/src/main/kotlin/org/microg/gms/gcm/registeration/ChimeGmsRegistrationHelper.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/gcm/registeration/ChimeGmsRegistrationHelper.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.withContext
 import org.microg.gms.auth.AuthConstants
 import org.microg.gms.checkin.LastCheckinInfo
 import org.microg.gms.common.Constants
+import org.microg.gms.common.PackageUtils
 import org.microg.gms.common.Utils
 import org.microg.gms.gcm.GMS_NOTS_BASE_URL
 import org.microg.gms.gcm.GMS_NOTS_OAUTH_SERVICE
@@ -128,7 +129,7 @@ class ChimeGmsRegistrationHelper(val context: Context) {
     private fun buildDeviceContext() = GmsDeviceContext.build {
         languageTag = if (SDK_INT >= 24) LocaleList.getDefault().get(0).toLanguageTag() else Locale.getDefault().language
         gmsDeviceProfile = GmsDeviceProfile.build {
-            val packageInfo = context.packageManager.getPackageInfo(Constants.GMS_PACKAGE_NAME, 0)
+            val packageInfo = context.packageManager.getPackageInfo(PackageUtils.getSelfPackageName(context), 0)
             density = context.resources.displayMetrics.density
             versionName = packageInfo.versionName
             release = Build.VERSION.RELEASE

--- a/play-services-core/src/main/kotlin/org/microg/gms/ui/AccountsFragment.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/ui/AccountsFragment.kt
@@ -25,7 +25,6 @@ import com.google.android.gms.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.microg.gms.auth.AuthConstants
-import org.microg.gms.common.Constants
 import org.microg.gms.gcm.ACTION_GCM_CONNECTED
 import org.microg.gms.gcm.ACTION_GCM_REGISTER_ALL_ACCOUNTS
 import org.microg.gms.people.DatabaseHelper
@@ -67,7 +66,7 @@ class AccountsFragment : PreferenceFragmentCompat() {
 
     private fun registerGcmInGms() {
         Intent(ACTION_GCM_REGISTER_ALL_ACCOUNTS).apply {
-            `package` = Constants.GMS_PACKAGE_NAME
+            `package` = requireContext().packageName
         }.let { requireContext().sendBroadcast(it) }
     }
 

--- a/play-services-maps/core/hms/src/main/kotlin/org/microg/gms/maps/hms/utils/MapContext.kt
+++ b/play-services-maps/core/hms/src/main/kotlin/org/microg/gms/maps/hms/utils/MapContext.kt
@@ -14,9 +14,10 @@ import androidx.annotation.RequiresApi
 import com.huawei.hms.maps.MapClientIdentify
 import com.huawei.hms.maps.utils.MapClientUtil
 import org.microg.gms.common.Constants
+import org.microg.gms.maps.MapsRemoteContextHolder
 import java.io.File
 
-class MapContext(private val context: Context) : ContextWrapper(context.createPackageContext(Constants.GMS_PACKAGE_NAME, Context.CONTEXT_INCLUDE_CODE or Context.CONTEXT_IGNORE_SECURITY)) {
+class MapContext(private val context: Context) : ContextWrapper(MapsRemoteContextHolder.require()) {
     private var layoutInflater: LayoutInflater? = null
     private val appContext: Context
         get() = context.applicationContext ?: context

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/utils/MapContext.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/utils/MapContext.kt
@@ -21,10 +21,10 @@ import android.content.ContextWrapper
 import android.content.Intent
 import android.content.SharedPreferences
 import android.view.LayoutInflater
-import org.microg.gms.common.Constants
+import org.microg.gms.maps.MapsRemoteContextHolder
 import java.io.File
 
-class MapContext(private val context: Context) : ContextWrapper(context.createPackageContext(Constants.GMS_PACKAGE_NAME, Context.CONTEXT_INCLUDE_CODE or Context.CONTEXT_IGNORE_SECURITY)) {
+class MapContext(private val context: Context) : ContextWrapper(MapsRemoteContextHolder.require()) {
     private var layoutInflater: LayoutInflater? = null
     private val appContext: Context
         get() = context.applicationContext ?: context

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/utils/MultiArchLoader.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/utils/MultiArchLoader.kt
@@ -21,8 +21,8 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.util.Log
 import com.mapbox.mapboxsdk.LibraryLoader
-import org.microg.gms.common.Constants
 import org.microg.gms.common.PackageUtils
+import org.microg.gms.maps.MapsRemoteContextHolder
 import java.io.*
 import java.util.zip.ZipFile
 
@@ -42,8 +42,9 @@ class MultiArchLoader(private val mapContext: Context, private val appContext: C
                 val cacheFileStamp = File("${appContext.cacheDir.absolutePath}/.gmscore/$path.stamp")
                 val cacheVersion = kotlin.runCatching { cacheFileStamp.readText() }.getOrNull()
                 // TODO: Use better version indicator
-                val mapVersion = PackageUtils.versionName(mapContext, Constants.GMS_PACKAGE_NAME)
-                val apkFile = File(mapContext.packageCodePath)
+                val gmsContext = MapsRemoteContextHolder.require()
+                val mapVersion = PackageUtils.versionName(gmsContext, gmsContext.packageName)
+                val apkFile = File(gmsContext.packageCodePath)
                 if (!cacheFile.exists() || cacheVersion == null || cacheVersion != mapVersion) {
                     val zipFile = ZipFile(apkFile)
                     val entry = zipFile.getEntry(path)

--- a/play-services-maps/core/vtm/src/main/java/org/microg/gms/maps/vtm/ApplicationContextWrapper.java
+++ b/play-services-maps/core/vtm/src/main/java/org/microg/gms/maps/vtm/ApplicationContextWrapper.java
@@ -18,9 +18,8 @@ package org.microg.gms.maps.vtm;
 
 import android.content.Context;
 import android.content.ContextWrapper;
-import android.content.pm.PackageManager;
 
-import org.microg.gms.common.Constants;
+import org.microg.gms.maps.MapsRemoteContextHolder;
 
 public class ApplicationContextWrapper extends ContextWrapper {
     private Context applicationContext;
@@ -31,12 +30,7 @@ public class ApplicationContextWrapper extends ContextWrapper {
     }
 
     public static ApplicationContextWrapper gmsContextWithAttachedApplicationContext(Context applicationContext) {
-        try {
-            Context context = applicationContext.createPackageContext(Constants.GMS_PACKAGE_NAME, CONTEXT_INCLUDE_CODE & CONTEXT_IGNORE_SECURITY);
-            return new ApplicationContextWrapper(context, applicationContext);
-        } catch (PackageManager.NameNotFoundException e) {
-            throw new RuntimeException(e);
-        }
+        return new ApplicationContextWrapper(MapsRemoteContextHolder.require(), applicationContext);
     }
 
     public static ApplicationContextWrapper matchingApplicationContext(Context context) {

--- a/play-services-maps/src/main/java/org/microg/gms/maps/MapsContextLoader.java
+++ b/play-services-maps/src/main/java/org/microg/gms/maps/MapsContextLoader.java
@@ -58,15 +58,19 @@ public class MapsContextLoader {
             }
             MapsContextLoader.mapsContext = mapsContext;
         }
+        MapsRemoteContextHolder.set(MapsContextLoader.mapsContext);
         return mapsContext;
     }
 
     public static ICreator getCreator(Context context, @Nullable MapsInitializer.Renderer preferredRenderer) {
         Log.d(TAG, "preferredRenderer: " + preferredRenderer);
+        Context mapsContext = getMapsContext(context, preferredRenderer);
         if (creator == null) {
             Log.d(TAG, "Making Creator dynamically");
             try {
-                Context mapsContext = getMapsContext(context, preferredRenderer);
+                if (mapsContext == null) {
+                    throw new IllegalStateException("Unable to obtain remote maps context");
+                }
                 Class<?> clazz = mapsContext.getClassLoader().loadClass("com.google.android.gms.maps.internal.CreatorImpl");
                 creator = ICreator.Stub.asInterface((IBinder) clazz.newInstance());
                 creator.initV2(ObjectWrapper.wrap(mapsContext.getResources()), Constants.GMS_VERSION_CODE);

--- a/play-services-maps/src/main/java/org/microg/gms/maps/MapsRemoteContextHolder.java
+++ b/play-services-maps/src/main/java/org/microg/gms/maps/MapsRemoteContextHolder.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.maps;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class MapsRemoteContextHolder {
+    private static volatile Context remoteContext;
+
+    private MapsRemoteContextHolder() {
+    }
+
+    public static void set(@Nullable Context context) {
+        remoteContext = context;
+    }
+
+    @Nullable
+    public static Context get() {
+        return remoteContext;
+    }
+
+    @NonNull
+    public static Context require() {
+        Context context = remoteContext;
+        if (context == null) {
+            throw new IllegalStateException("Maps remote context has not been initialized");
+        }
+        return context;
+    }
+}


### PR DESCRIPTION
- Related user report: https://github.com/ReVanced/revanced-patches/issues/6602

## Summary
This PR addresses an Android Auto crash loop when connecting to ReVanced YouTube Music.

During Android Auto media binding, YouTube Music repeatedly crashes with:
`java.lang.IllegalStateException: Missing DynamiteApplicationContext.`

The failure occurs in the GmsCore Dynamite `googlecertificates` path and breaks Android Auto media integration (spinner / no controls / no artwork), while playback may still continue.

## Problem
When Android Auto binds `com.google.android.apps.youtube.music.mediabrowser.MusicBrowserService`, the app crashes in this chain:

- `com.google.android.gms.common.GoogleCertificatesImpl`
- `java.lang.IllegalStateException: Missing DynamiteApplicationContext`
- `com.google.android.apps.youtube.music.mediabrowser.MusicBrowserService.e(PG:137)`

Android Auto then loses the media browser connection and repeatedly retries/restarts the service.

## Regression source
The regression was introduced by the package rename work:

- `e6cd2487` (same logical change also appears as `c778936c`):  
  `feat: Allow side-by-side installation with Google services by renaming permissions and authorities`

### What changed in that commit
- `play-services-core/build.gradle:122`
  - `applicationId = "app.revanced.android.gms"`
- `play-services-core/build.gradle:134`
  - `resValue "string", "package_id", "app.revanced.android.gms"`

### Why this caused the crash
After that rename, some runtime code paths still resolved remote/dynamite context using only the old package assumption (`com.google.android.gms`), which can produce an invalid module context under renamed GmsCore.

Pre-fix examples:

- `play-services-core/src/main/java/com/google/android/gms/chimera/DynamiteContextFactory.java` (pre-fix line 52)
  - `originalContext.createPackageContext(Constants.GMS_PACKAGE_NAME, 0);`
- `play-services-base/src/main/java/com/google/android/gms/common/GooglePlayServicesUtil.java` (pre-fix lines 140, 153)
  - `createPackageContext(Constants.GMS_PACKAGE_NAME, ...)`
  - `getResourcesForApplication(Constants.GMS_PACKAGE_NAME)`

When Android Auto triggers YT Music media-browser startup, this mismatch appears in the `googlecertificates` Dynamite path and terminates with:
- `java.lang.IllegalStateException: Missing DynamiteApplicationContext.`

## Environment
| Component | Value |
| --- | --- |
| Device | Samsung `SM-S926U` (`e2q`) |
| Android | `16` (SDK `36`) |
| Security patch | `2026-01-01` |
| Build fingerprint | `samsung/e2qsqw/e2q:16/BP2A.250605.031.A3/S926USQS4CZA1:user/release-keys` |
| Android Auto | `com.google.android.projection.gearhead` `16.1.660414-release` (`versionCode=161660414`) |
| ReVanced YouTube Music | `8.10.52` (`versionCode=81052240`) |
| ReVanced GmsCore | `0.3.13.2.250932` (`versionCode=250932004`) |
| Bugreport capture | `2026-02-18 20:34:18` |

## Evidence
### 1) Crash loop in YT Music media browser startup
```text
02-18 20:34:08.658 E AndroidRuntime: FATAL EXCEPTION: main
02-18 20:34:08.658 E AndroidRuntime: Process: app.revanced.android.apps.youtube.music, PID: 20756
02-18 20:34:08.658 E AndroidRuntime: java.lang.IllegalStateException: Missing DynamiteApplicationContext.
02-18 20:34:08.658 E AndroidRuntime: at com.google.android.gms.common.GoogleCertificatesImpl.a(...)
02-18 20:34:08.658 E AndroidRuntime: at com.google.android.apps.youtube.music.mediabrowser.MusicBrowserService.e(PG:137)
02-18 20:34:08.658 E AndroidRuntime: at android.service.media.MediaBrowserService$ServiceState.connectOnHandler(...)

02-18 20:33:51.884 W ActivityManager: Process app.revanced.android.apps.youtube.music has crashed too many times, killing! Reason: crashed quickly
```

<details>
<summary>Full stacktrace (raw)</summary>

```text
02-18 20:34:08.502 10526 20756 20756 W DynamiteModule: Local module descriptor class for com.google.android.gms.googlecertificates not found.
02-18 20:34:08.502 10526 20756 20756 W DynamiteModule: IDynamite loader version = 2, no high precision latency measurement.
02-18 20:34:08.502 10526 20756 20756 W DynamiteModule: IDynamite loader version = 2
02-18 20:34:08.502 10526 20756 20756 D GmsDynamiteLoaderImpl: createModuleContext for com.google.android.gms.googlecertificates at version 1
02-18 20:34:08.502 10526 20756 20756 D DynamiteContextFactory: Created and cached a new DynamiteContext for cacheKey: com.google.android.gms.googlecertificates-app.revanced.android.apps.youtube.music
02-18 20:34:08.502 10526 20756 20756 W s.youtube.music: Unsupported class loader: java.lang.Class<com.google.android.gms.chimera.container.FilteredClassLoader>

02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: FATAL EXCEPTION: main
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: Process: app.revanced.android.apps.youtube.music, PID: 20756
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: java.lang.IllegalStateException: Missing DynamiteApplicationContext.
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at com.google.android.gms.common.GoogleCertificatesImpl.a(:com.google.android.gms@260438035@26.04.38 (260400-867839860):10)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at com.google.android.gms.common.GoogleCertificatesImpl.<init>(:com.google.android.gms@260438035@26.04.38 (260400-867839860):4)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at java.lang.Class.newInstance(Native Method)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at sus.d(PG:11)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at sfx.d(PG:30)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at sgm.a(PG:32)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at sgm.c(PG:1)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at keh.g(PG:70)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at com.google.android.apps.youtube.music.mediabrowser.MusicBrowserService.e(PG:137)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at bof.onGetRoot(PG:119)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at android.service.media.MediaBrowserService$ServiceState.connectOnHandler(MediaBrowserService.java:784)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at android.service.media.MediaBrowserService$ServiceBinder.lambda$connect$0(MediaBrowserService.java:251)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at android.service.media.MediaBrowserService$ServiceBinder$$ExternalSyntheticLambda1.run(D8$$SyntheticClass:0)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:995)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:103)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:273)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:363)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:10060)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:632)
02-18 20:34:08.658 10526 20756 20756 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:975)

02-18 20:33:51.010  1000  2558  3973 I am_crash: [19847,0,app.revanced.android.apps.youtube.music,553369156,java.lang.IllegalStateException,Missing DynamiteApplicationContext.,:com.google.android.gms@260438035@26.04.38 (260400-867839860),10,0]
02-18 20:33:51.883  1000  2558  6755 I am_crash: [20273,0,app.revanced.android.apps.youtube.music,551272004,java.lang.IllegalStateException,Missing DynamiteApplicationContext.,:com.google.android.gms@260438035@26.04.38 (260400-867839860),10,0]
02-18 20:34:08.661  1000  2558  6751 I am_crash: [20756,0,app.revanced.android.apps.youtube.music,551272004,java.lang.IllegalStateException,Missing DynamiteApplicationContext.,:com.google.android.gms@260438035@26.04.38 (260400-867839860),10,0]

02-18 20:33:51.884  1000  2558  6755 W ActivityManager: Process app.revanced.android.apps.youtube.music has crashed too many times, killing! Reason: crashed quickly
```

</details>

### 2) Dynamite `googlecertificates` context created immediately before crash
```text
02-18 20:34:08.502 W DynamiteModule: Local module descriptor class for com.google.android.gms.googlecertificates not found.
02-18 20:34:08.502 D GmsDynamiteLoaderImpl: createModuleContext for com.google.android.gms.googlecertificates at version 1
02-18 20:34:08.502 D DynamiteContextFactory: Created and cached a new DynamiteContext for cacheKey: com.google.android.gms.googlecertificates-app.revanced.android.apps.youtube.music
```

### 3) Android Auto is actively binding YT Music media service
```text
Start proc ... app.revanced.android.apps.youtube.music ... for service .../MusicBrowserService
GH.MediaBCConnection: onConnectionSuspended component=.../MusicBrowserService
Scheduling restart of crashed service .../MusicBrowserService in 20000ms
```

### 4) Additional service/module warnings seen during the same window
```text
Unable to start service Intent { act=com.google.android.gms.phenotype.service.START ... pkg=app.revanced.android.gms } U=0: not found
No such module known: com.google.android.gms.cast.framework.dynamite
returning temp fix module version for com.google.android.gms.cast.framework.dynamite. Cast API wil not be functional!
```

## Proposed fixes in this PR
1. `d2ec2657` - `fix(chimera): resolve package context for renamed GmsCore`
   - Updates `DynamiteContextFactory` so it no longer assumes a single package name when creating the GMS package context.
   - It now tries valid package IDs for renamed and stock installs to avoid context lookup failures during Dynamite module loading.
