### PR TITLE
Render a usable map when no Mapbox/Stadia key is configured

### DIFF
--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/MapFragment.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/MapFragment.kt
@@ -53,7 +53,7 @@ class MapFragmentImpl(private val activity: Activity) : IMapFragmentDelegate.Stu
         if (options == null) {
             options = GoogleMapOptions()
         }
-        if (options?.liteMode == true) {
+        if (options?.liteMode == true && !useKeylessRasterTiles()) {
             map = LiteGoogleMapImpl(activity, options ?: GoogleMapOptions())
         } else {
             map = GoogleMapImpl(activity, options ?: GoogleMapOptions())
@@ -66,7 +66,7 @@ class MapFragmentImpl(private val activity: Activity) : IMapFragmentDelegate.Stu
         }
         Log.d(TAG, "onCreateView: ${options?.camera?.target}")
         if (map == null) {
-            map = if (options?.liteMode == true) {
+            map = if (options?.liteMode == true && !useKeylessRasterTiles()) {
                 LiteGoogleMapImpl(activity, options ?: GoogleMapOptions())
             } else {
                 GoogleMapImpl(activity, options ?: GoogleMapOptions())

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/MapView.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/MapView.kt
@@ -34,7 +34,9 @@ class MapViewImpl(private val context: Context, options: GoogleMapOptions?) : IM
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.d(TAG, "onCreate: ${options?.camera?.target}")
-        map = if (options.liteMode) {
+        // The lite-mode snapshotter draws a logo overlay that MapLibre cannot build for the
+        // key-less raster fallback (crashes in MapSnapshotter). Use the full renderer in that case.
+        map = if (options.liteMode && !useKeylessRasterTiles()) {
             LiteGoogleMapImpl(context, options)
         } else {
             GoogleMapImpl(context, options)

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/Styles.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/Styles.kt
@@ -39,10 +39,46 @@ const val KEY_SOURCE_URL = "url"
 const val KEY_SOURCE_TILES = "tiles"
 
 
-fun getStyle(
-    context: MapContext, mapType: Int, styleOptions: MapStyleOptions?, styleFromFileWorkaround: Boolean = false
-): Style.Builder {
+/**
+ * When no Mapbox or Stadia key is configured at build time, the vector styles cannot fetch any tiles
+ * and the map renders blank. In that case fall back to key-less OpenStreetMap raster tiles, which
+ * MapLibre renders without any access token, so the map remains usable out of the box.
+ */
+internal fun useKeylessRasterTiles(): Boolean =
+    BuildConfig.MAPBOX_KEY.isEmpty() && BuildConfig.STADIA_KEY.isEmpty()
 
+private fun buildKeylessRasterStyle(mapType: Int): JSONObject {
+    val tilesUrl = when (mapType) {
+        GoogleMap.MAP_TYPE_SATELLITE, GoogleMap.MAP_TYPE_HYBRID ->
+            "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+        else -> "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+    }
+    return JSONObject().apply {
+        put("version", 8)
+        put("sources", JSONObject().apply {
+            put("osm", JSONObject().apply {
+                put("type", "raster")
+                put("tiles", JSONArray().put(tilesUrl))
+                put("tileSize", 256)
+                put("maxzoom", 19)
+            })
+        })
+        put("layers", JSONArray().apply {
+            put(JSONObject().apply {
+                put("id", "background")
+                put("type", "background")
+                put("paint", JSONObject().put("background-color", "#e6e4e0"))
+            })
+            put(JSONObject().apply {
+                put("id", "osm")
+                put("type", "raster")
+                put("source", "osm")
+            })
+        })
+    }
+}
+
+private fun loadVectorStyle(context: MapContext, mapType: Int): JSONObject {
     val styleJson = JSONObject(
         context.assets.open(
             if (BuildConfig.STADIA_KEY.isNotEmpty()) when (mapType) {
@@ -74,6 +110,18 @@ fun getStyle(
                 }
             }
         }
+    }
+    return styleJson
+}
+
+fun getStyle(
+    context: MapContext, mapType: Int, styleOptions: MapStyleOptions?, styleFromFileWorkaround: Boolean = false
+): Style.Builder {
+
+    val styleJson = if (useKeylessRasterTiles()) {
+        buildKeylessRasterStyle(mapType)
+    } else {
+        loadVectorStyle(context, mapType)
     }
 
     styleOptions?.apply(styleJson)

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/utils/MapContext.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/utils/MapContext.kt
@@ -24,7 +24,7 @@ import android.view.LayoutInflater
 import org.microg.gms.common.Constants
 import java.io.File
 
-class MapContext(private val context: Context) : ContextWrapper(context.createPackageContext(Constants.GMS_PACKAGE_NAME, Context.CONTEXT_INCLUDE_CODE or Context.CONTEXT_IGNORE_SECURITY)) {
+class MapContext(private val context: Context) : ContextWrapper(context.createPackageContext(resolveSelfPackage(context), Context.CONTEXT_INCLUDE_CODE or Context.CONTEXT_IGNORE_SECURITY)) {
     private var layoutInflater: LayoutInflater? = null
     private val appContext: Context
         get() = context.applicationContext ?: context
@@ -77,5 +77,21 @@ class MapContext(private val context: Context) : ContextWrapper(context.createPa
 
     companion object {
         val TAG = "GmsMapContext"
+
+        // ReVanced fix: GmsCore may be installed under app.revanced.android.gms instead of
+        // com.google.android.gms. Resolve to whichever GmsCore package is actually installed so
+        // we load the correct APK (the one bundling libmapbox-gl.so). Prefer the ReVanced package
+        // to avoid accidentally binding to a (possibly disabled) real Google GMS install.
+        fun resolveSelfPackage(context: Context): String {
+            for (pkg in listOf(Constants.USER_MICROG_PACKAGE_NAME, Constants.GMS_PACKAGE_NAME)) {
+                try {
+                    context.packageManager.getApplicationInfo(pkg, 0)
+                    return pkg
+                } catch (e: Exception) {
+                    // not installed, try next candidate
+                }
+            }
+            return Constants.GMS_PACKAGE_NAME
+        }
     }
 }

--- a/play-services-maps/src/main/java/com/google/android/gms/maps/model/BitmapDescriptorFactory.java
+++ b/play-services-maps/src/main/java/com/google/android/gms/maps/model/BitmapDescriptorFactory.java
@@ -18,7 +18,7 @@ public class BitmapDescriptorFactory {
         BitmapDescriptorFactory.delegate = delegate;
     }
     private static IBitmapDescriptorFactoryDelegate getDelegate() {
-        if (delegate == null) throw new IllegalStateException("CameraUpdateFactory is not initialized");
+        if (delegate == null) throw new IllegalStateException("BitmapDescriptorFactory is not initialized");
         return delegate;
     }
 }


### PR DESCRIPTION
## Summary

Makes the map render a usable basemap when GmsCore is built **without** a Mapbox or Stadia key (the common case for community builds), and fixes the renderer failing to load under a renamed package.

Verified end-to-end on-device with Google Photos' Map/Places (MapExplore) feature, which previously showed a blank/broken map even after the crash was worked around.

## Changes

- **`fix(maps)`: Correct `BitmapDescriptorFactory` error message.**
  `getDelegate()` threw an `IllegalStateException` mentioning `CameraUpdateFactory` instead of `BitmapDescriptorFactory`.

- **`fix(maps)`: Load the renderer from the installed GmsCore package.**
  `MapContext` hardcoded `com.google.android.gms` when creating the package context. When GmsCore is installed under a different package name (e.g. `app.revanced.android.gms`), this bound to the wrong package — or a disabled real Google Play Services install — so the bundled `libmapbox-gl.so` could not be extracted and the map failed to render (`UnsatisfiedLinkError`). It now resolves whichever GmsCore package is actually installed.

- **`feat(maps)`: Fall back to key-less OpenStreetMap tiles when no map key is set.**
  When neither `MAPBOX_KEY` nor `STADIA_KEY` is configured at build time, the vector styles cannot fetch tiles and the map renders blank. Fall back to key-less OpenStreetMap raster tiles (rendered by MapLibre without any token). This fallback is gated on both keys being empty, so keyed builds keep the existing styled vector maps and lite mode. Lite mode is bypassed only in the key-less fallback, because the snapshotter cannot build the logo overlay for a raster style.

## Context

Investigated as part of ReVanced discussion #1068 (Google Photos "Photos won't run without Google Play Services" / `IBitmapDescriptorFactory is not initialized`). The crash itself is fixed by a separate revanced-patches change; this PR is what makes an actual map appear.
