### PR TITLE
fix: Use original action instead of incorrectly renamed names

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -913,7 +913,7 @@
 
         <service android:name="org.microg.gms.phenotype.PhenotypeService">
             <intent-filter>
-                <action android:name="app.revanced.android.gms.phenotype.service.START" />
+                <action android:name="com.google.android.gms.phenotype.service.START" />
             </intent-filter>
         </service>
 
@@ -1235,7 +1235,7 @@
                 <action android:name="com.google.android.gms.fitness.GoogleFitnessService.START" />
                 <action android:name="com.google.android.gms.fitness.InternalApi" />
                 <action android:name="com.google.android.gms.fitness.SensorsApi" />
-                <action android:name="app.revanced.android.gms.fonts.service.START" />
+                <action android:name="com.google.android.gms.fonts.service.START" />
                 <action android:name="com.google.android.gms.freighter.service.START" />
                 <action android:name="com.google.android.gms.growth.service.START" />
                 <action android:name="com.google.android.gms.googlehelp.service.GoogleHelpService.START" />


### PR DESCRIPTION
## Summary

Two service `intent-filter` actions in `play-services-core/src/main/AndroidManifest.xml` were declared with the **application package** instead of the canonical `com.google.android.gms.*` action:

```xml
<action android:name="app.revanced.android.gms.phenotype.service.START" />
<action android:name="app.revanced.android.gms.fonts.service.START" />
```

Every other service in the manifest (~96) uses `com.google.android.gms.*.service.START`, and so does GmsCore's own service map:

```java
// play-services-basement/.../org/microg/gms/common/GmsService.java
PHENOTYPE(51, "com.google.android.gms.phenotype.service.START"),
FONT_API(132, "com.google.android.gms.fonts.service.START"),
```

Clients (and `GmsClient` internally) bind these services by the **canonical** action, so with the action registered under `app.revanced.android.gms.*` the two services were **unreachable** on a repackaged install.

## Root cause

These are **hardcoded literals** in the manifest (not an `${applicationId}` placeholder). They appear to be collateral of a **prefix-based** package rename: renaming the two provider authorities

- `com.google.android.gms.phenotype` → `app.revanced.android.gms.phenotype`
- `com.google.android.gms.fonts` → `app.revanced.android.gms.fonts`

also mutated the action strings that **start with** those same prefixes (`…phenotype.service.START`, `…fonts.service.START`). That's why exactly these two of ~98 actions were affected.

## Why the actions must be canonical (but the authorities must not)

- **Provider authorities** must be globally unique per device, so they are correctly renamed to `app.revanced.*` to allow installing alongside Google Play Services. This PR leaves them untouched.
- **Service actions** have no uniqueness constraint. GMS clients bind with an **explicit** intent that sets the target package (e.g. `Intent(action).setPackage("app.revanced.android.gms")`), so a canonical action does not collide with a real-GMS side-by-side install — resolution is confined to the named package. The ~96 other canonical-action services already work this way; these two just need to match.

## Impact

Any Google app using Phenotype (feature-flag/config) hit a retry loop:

```
ActivityManager: Unable to start service Intent { act=com.google.android.gms.phenotype.service.START pkg=app.revanced.android.gms } U=0: not found
GmsClient: unable to connect to service: com.google.android.gms.phenotype.service.START
FlagStore: Phenotype.API is not available on this device (API_UNAVAILABLE)
```

For example, **Google Photos** loaded very slowly and its config kept resetting.

## Fix

Use the canonical `com.google.android.gms.{phenotype,fonts}.service.START` actions, matching the other ~96 services and `GmsService.java`.

- **Phenotype** is a genuinely implemented service (`PhenotypeService`), so this fully restores it.
- **Fonts** (`FONT_API`) is handled by `DummyService`, which returns `API_DISABLED`; the fix stops the "service not found" retry storm and matches upstream, but Downloadable Fonts remains a stub (real font delivery is via the separate `FontsProvider`, which is unchanged).

## Verification

On a repackaged install with Google Photos:

**Before:** constant `phenotype.service.START ... not found` + `Phenotype.API is not available`.

**After:**
```
PhenotypeService: onBind ... pkg=app.revanced.android.gms
PhenotypeService: bound by: ...packageName="com.google.android.apps.photos"...
PhenotypeService: commitToConfiguration()   ✓
```
Home displayed in ~0.5s (previously slow), Collections loads normally.
